### PR TITLE
[Docker] Return exit code of openssl rand on test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,4 +20,4 @@ jobs:
           docker tag ghcr.io/lacchain/pqe-rpc-server-test:latest pqe-rpc-server-test:latest
       - uses: actions/checkout@v2
       - name: Run integration test
-        run: docker-compose -f docker-compose.test.yml up --build
+        run: docker-compose -f docker-compose.test.yml up --build --exit-code-from openssl-pqe-engine

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,9 @@ openssl engine\n\
 #tail -f /var/log/syslog\n'\
 sleep 15\n\
 openssl rand 24\n\
-curl -v http://$SERVER_HOST:8080/shutdown\n'\
+ret=$?\n\
+curl -v http://$SERVER_HOST:8080/shutdown\n\
+exit $ret\n'\
 >> /run.sh
 RUN chmod +x /run.sh
 


### PR DESCRIPTION
The container should exit with the code of the `openssl rand` call

Note: Github Action failure expected